### PR TITLE
Add llama-stack-provider-trustyai-garak to jira components mapping

### DIFF
--- a/config/jira_components_mapping.json
+++ b/config/jira_components_mapping.json
@@ -22,7 +22,8 @@
     "AI Safety": [
         "red-hat-data-services/trustyai-explainability",
         "red-hat-data-services/trustyai-explainability-python",
-        "red-hat-data-services/trustyai-service-operator"
+        "red-hat-data-services/trustyai-service-operator",
+        "red-hat-data-services/llama-stack-provider-trustyai-garak"
     ],
     "AI Evaluations": [
         "red-hat-data-services/lm-evaluation-harness",


### PR DESCRIPTION
Adding [llama-stack-provider-trustyai-garak](https://github.com/red-hat-data-services/llama-stack-provider-trustyai-garak) to the jira components mapping. Added to Snyk [here](https://app.snyk.io/org/red-hat-openshift-data-science-rhods/projects?groupBy=targets&before&after&searchQuery=garak&sortBy=highest+severity&filters[Show]=&filters[Integrations]=&filters[CollectionIds]=).