### PR TITLE
Update Llama Stack Core repo URLs for OGX rename

### DIFF
--- a/config/jira_components_mapping.json
+++ b/config/jira_components_mapping.json
@@ -75,8 +75,8 @@
         "red-hat-data-services/feast"
     ],
     "Llama Stack Core": [
-        "red-hat-data-services/llama-stack-k8s-operator",
-        "opendatahub-io/llama-stack"
+        "red-hat-data-services/ogx-k8s-operator",
+        "opendatahub-io/ogx"
     ],
     "Kubeflow Unified SDK": [
         "opendatahub-io/kubeflow-sdk"


### PR DESCRIPTION
[RHAIENG-4521](https://redhat.atlassian.net/browse/RHAIENG-4521)

### Description
Both repos under the "Llama Stack Core" Jira component have been renamed upstream as part of the OGX rename (RHAIENG-4461):

- `red-hat-data-services/llama-stack-k8s-operator` → `red-hat-data-services/ogx-k8s-operator`
- `opendatahub-io/llama-stack` → `opendatahub-io/ogx`

This updates `jira_components_mapping.json` to reflect the new repo names so Snyk findings route to the correct Jira component.

The Jira component name itself ("Llama Stack Core") is unchanged here. Renaming the component is tracked separately in [RHAIENG-5108](https://redhat.atlassian.net/browse/RHAIENG-5108).

### How Has This Been Tested?
Verified both new repo names exist on GitHub (`gh api repos/<name>`).