### PR TITLE
Add trainer-operator to jira components mapping under Training Kubeflow

### DIFF
--- a/config/jira_components_mapping.json
+++ b/config/jira_components_mapping.json
@@ -64,6 +64,7 @@
     "Training Kubeflow": [
         "red-hat-data-services/training-operator",
         "red-hat-data-services/trainer",
+        "red-hat-data-services/trainer-operator",
         "foundation-model-stack/fms-hf-tuning"
     ],
     "Notebooks Server": [


### PR DESCRIPTION
## Summary
- Adds `red-hat-data-services/trainer-operator` to the Training Kubeflow component in `config/jira_components_mapping.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)