### PR TITLE
Update Spark Operator component name to Kubeflow Spark Operator

### DIFF
--- a/config/jira_components_mapping.json
+++ b/config/jira_components_mapping.json
@@ -98,8 +98,8 @@
     "Model as a Service": [
         "red-hat-data-services/models-as-a-service"
     ],
-    "Spark Operator": [
-        "red-hat-data-services/spark-operator"
+    "Kubeflow Spark Operator": [
+        "red-hat-data-services/kubeflow-spark-operator"
     ],
     "Inference Gateway": [
         "opendatahub-io/ai-gateway-payload-processing"


### PR DESCRIPTION
    This PR updates the component name and repository path for the Spark Operator to reflect its proper Kubeflow designation.

  ## Changes
  - Renamed `Spark Operator` to `Kubeflow Spark Operator` in `config/jira_components_mapping.json`
  - Updated repository path from `red-hat-data-services/spark-operator` to `red-hat-data-services/kubeflow-spark-operator`

  ## Motivation
  This change reconciles a mismatch in component names between Jira projects and the configuration file, ensuring consistent naming across systems.

  ## Files Modified
  - `config/jira_components_mapping.json` (lines 101-102)